### PR TITLE
Fixing nltk data errors once more

### DIFF
--- a/scripts/visualization_generator.py
+++ b/scripts/visualization_generator.py
@@ -12,6 +12,7 @@ from nltk.stem import WordNetLemmatizer
 nltk.download('punkt')
 nltk.download('wordnet')
 nltk.download('vader_lexicon')
+nltk.download('stopwords')
 
 class visualizationGenerator:
     def __init__(self, seasonFrom=1, episodeFrom=1  , seasonTo=1, episodeTo=1):


### PR DESCRIPTION
Added `nltk.download("stopwords")` which was supposed to be included in the last bugfix. https://github.com/DSProjects2024/ThroneTalk--AI-powered-character-Dialogue-Generation/pull/18/commits/982b5ff3458a3294d82e55a9d8750f001b90dc34